### PR TITLE
Handle temporary AWS credentials

### DIFF
--- a/src/main/scala/fly/play/aws/Aws.scala
+++ b/src/main/scala/fly/play/aws/Aws.scala
@@ -1,23 +1,15 @@
 package fly.play.aws
 
 import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.SimpleTimeZone
-import scala.concurrent.Future
+import java.util.{Locale, SimpleTimeZone}
+
 import fly.play.aws.auth.Signer
-import play.api.http.ContentTypeOf
-import play.api.http.Writeable
+import play.api.http.{ContentTypeOf, Writeable}
 import play.api.libs.iteratee.Iteratee
-import play.api.libs.ws.ResponseHeaders
-import play.api.libs.ws.SignatureCalculator
-import play.api.libs.ws.WSRequest
 import play.api.Application
-import play.api.libs.ws.WSRequestHolder
-import play.api.libs.ws.WSSignatureCalculator
-import play.api.libs.ws.WSResponseHeaders
-import scala.concurrent.ExecutionContext
-import play.api.libs.ws.WS
-import play.api.libs.ws.WSResponse
+
+import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.{WS, WSRequestHolder, WSResponse, WSResponseHeaders}
 
 /**
  * Amazon Web Services

--- a/src/main/scala/fly/play/aws/PlayConfiguration.scala
+++ b/src/main/scala/fly/play/aws/PlayConfiguration.scala
@@ -9,5 +9,7 @@ object PlayConfiguration {
    * a PlayException when the key could not be found.
    */
   def apply(key: String)(implicit app: Application): String =
-    app.configuration.getString(key).getOrElse(throw new PlayException("Configuration error", "Could not find " + key + " in settings"))
+    optional(key).getOrElse(throw new PlayException("Configuration error", "Could not find " + key + " in settings"))
+
+  def optional(key: String)(implicit app: Application): Option[String] = app.configuration.getString(key)
 }

--- a/src/main/scala/fly/play/aws/auth/AwsCredentials.scala
+++ b/src/main/scala/fly/play/aws/auth/AwsCredentials.scala
@@ -1,23 +1,25 @@
 package fly.play.aws.auth
 
-import java.util.Date
 import fly.play.aws.PlayConfiguration
 import play.api.Application
 
 trait AwsCredentials {
   def accessKeyId: String
+
   def secretKey: String
+
+  def token: Option[String]
 }
 
-object AwsCredentials extends ((String, String) => AwsCredentials) {
-  def unapply(c: AwsCredentials): Option[(String, String)] =
-    Option(c) map { c => (c.accessKeyId, c.secretKey) }
+object AwsCredentials extends ((String, String, Option[String]) => AwsCredentials) {
+  def unapply(c: AwsCredentials): Option[(String, String, Option[String])] =
+    Option(c) map { c => (c.accessKeyId, c.secretKey, c.token)}
 
-  def apply(accessKeyId: String, secretKey: String): AwsCredentials =
-    SimpleAwsCredentials(accessKeyId, secretKey)
+  def apply(accessKeyId: String, secretKey: String, token: Option[String] = None): AwsCredentials =
+    SimpleAwsCredentials(accessKeyId, secretKey, token)
 
   implicit def fromConfiguration(implicit app: Application): AwsCredentials =
-    SimpleAwsCredentials(PlayConfiguration("aws.accessKeyId"), PlayConfiguration("aws.secretKey"))
+    SimpleAwsCredentials(PlayConfiguration("aws.accessKeyId"), PlayConfiguration("aws.secretKey"), PlayConfiguration.optional("aws.token"))
 }
 
-case class SimpleAwsCredentials(accessKeyId: String, secretKey: String) extends AwsCredentials
+case class SimpleAwsCredentials(accessKeyId: String, secretKey: String, token: Option[String] = None) extends AwsCredentials

--- a/src/test/scala/fly/play/aws/auth/AwsCredentialsSpec.scala
+++ b/src/test/scala/fly/play/aws/auth/AwsCredentialsSpec.scala
@@ -17,9 +17,10 @@ object AwsCredentialsSpec extends Specification with RunningFakePlayApplication 
       ok
     }
     "implement unapply" >> {
-      val AwsCredentials(a, b) = AwsCredentials("key", "secret")
+      val AwsCredentials(a, b, Some(t)) = AwsCredentials("key", "secret", Some("token"))
       a must_== "key"
       b must_== "secret"
+      t must_== "token"
     }
 
     def checkImplicit()(implicit c: AwsCredentials) = c


### PR DESCRIPTION
I've made a change to allow the use of temporary AWS credentials supplied by the STS service. To use temp credentials the caller needs to supply an extra header on the request, X-Amz-Security-Token, containing the token that STS supplies alongside the key and secret. This header also needs to be included in the signed header list.

The changes are backwardly compatible so that if the token is not supplied as part of the AwsCredentials object then the behaviour is the same as it was before the change.

I have added a test to Aws4SignerSpec to check that the header is added and signed correctly.
